### PR TITLE
[FIX] Fixed Offering Tooltip not showing up

### DIFF
--- a/src/main/java/com/danielkkrafft/wilddungeons/entity/Offering.java
+++ b/src/main/java/com/danielkkrafft/wilddungeons/entity/Offering.java
@@ -178,7 +178,7 @@ public class Offering extends Entity implements IEntityWithComplexSpawn {
     }
 
     public boolean isLookingAtMe(Player player, double dotFactor) {
-        Vec3 vec3 = player.getViewVector(1.0F).normalize();
+        Vec3 vec3 = player.getViewVector(1.0F).normalize(); //Prevent using Vec3 when doing actions eachFrame since Vec3 creates alot of unintentional objects
         Vec3 vec31 = new Vec3(this.getX() - player.getX(), this.getY()+0.5 - player.getEyeY(), this.getZ() - player.getZ());
         double length = vec31.length();
         vec31 = vec31.normalize();

--- a/src/main/java/com/danielkkrafft/wilddungeons/ui/ItemPreviewTooltipLayer.java
+++ b/src/main/java/com/danielkkrafft/wilddungeons/ui/ItemPreviewTooltipLayer.java
@@ -42,7 +42,10 @@ public class ItemPreviewTooltipLayer implements LayeredDraw.Layer {
         LocalPlayer player = Minecraft.getInstance().player;
         if (player == null || player.jumpableVehicle() != null) return;
 
-        if (previewEntity instanceof Offering offering && offering.isLookingAtMe(player, 1.2)) {
+        Entity entityAtCursor = Minecraft.getInstance().crosshairPickEntity; //This reference the current entity you are focusing your crosshair on
+        if (entityAtCursor == null) return;
+
+        if (entityAtCursor instanceof Offering offering) {
             renderTooltip(guiGraphics, offering, player);
             renderCursor(guiGraphics, offering);
         } else {


### PR DESCRIPTION
From "Offering.isLookingAtMe();" to "crosshairPick instanceof Offering"

When trying to detect the current focused entity, use pickedEntity (prevents the creation of unnecessary objects)